### PR TITLE
markup customization

### DIFF
--- a/markdown_checklist/extension.py
+++ b/markdown_checklist/extension.py
@@ -32,7 +32,10 @@ class ChecklistPostprocessor(Postprocessor):
         after = before.replace('<ul>', '<ul class="checklist">')
         return html.replace(before, after)
 
+    def render_checkbox(self, checked):
+        checked = ' checked' if checked else ''
+        return '<li><input type="checkbox" disabled%s>' % checked
+
     def _convert_checkbox(self, match):
         state = match.group(1)
-        checked = ' checked' if state != ' ' else ''
-        return '<li><input type="checkbox" disabled%s>' % checked
+        return self.render_checkbox(state != ' ')

--- a/markdown_checklist/extension.py
+++ b/markdown_checklist/extension.py
@@ -16,12 +16,16 @@ class ChecklistExtension(Extension):
 
     def __init__(self, **kwargs):
         self.config = {
+            "list_class": ["checklist",
+                    "class name to add to the list element"],
             "render_item": [render_item, "custom function to render items"]
         }
         super(ChecklistExtension, self).__init__(**kwargs)
 
     def extendMarkdown(self, md, md_globals):
-        postprocessor = ChecklistPostprocessor(self.getConfig("render_item"), md)
+        list_class = self.getConfig("list_class")
+        renderer = self.getConfig("render_item")
+        postprocessor = ChecklistPostprocessor(list_class, renderer, md)
         md.postprocessors.add('checklist', postprocessor, '>raw_html')
 
 
@@ -33,7 +37,8 @@ class ChecklistPostprocessor(Postprocessor):
     list_pattern = re.compile(r'(<ul>\n<li>\[[ Xx]\])')
     item_pattern = re.compile(r'^<li>\[([ Xx])\](.*)</li>$', re.MULTILINE)
 
-    def __init__(self, render_item, *args, **kwargs):
+    def __init__(self, list_class, render_item, *args, **kwargs):
+        self.list_class = list_class
         self.render_item = render_item
         super(ChecklistPostprocessor, self).__init__(*args, **kwargs)
 
@@ -42,7 +47,8 @@ class ChecklistPostprocessor(Postprocessor):
         return re.sub(self.item_pattern, self._convert_item, html)
 
     def _convert_list(self, match):
-        return match.group(1).replace("<ul>", '<ul class="checklist">')
+        return match.group(1).replace("<ul>",
+                '<ul class="%s">' % self.list_class)
 
     def _convert_item(self, match):
         state, caption = match.groups()

--- a/test/test_customization.py
+++ b/test/test_customization.py
@@ -1,0 +1,28 @@
+from markdown import markdown
+
+from markdown_checklist.extension import ChecklistExtension
+
+
+def render_item(checked):
+    checked = ' xecked' if checked else ''
+    return '<li><input type="checkbox" disabled%s>' % checked
+
+
+def test_checklists():
+    source = """
+* [ ] foo
+* [x] bar
+* [ ] baz
+    """.strip()
+
+    expected = """
+<ul class="checklist">
+<li><input type="checkbox" disabled> foo</li>
+<li><input type="checkbox" disabled xecked> bar</li>
+<li><input type="checkbox" disabled> baz</li>
+</ul>
+    """.strip()
+
+    html = markdown(source,
+            extensions=[ChecklistExtension(render_item=render_item)])
+    assert html == expected

--- a/test/test_customization.py
+++ b/test/test_customization.py
@@ -3,9 +3,10 @@ from markdown import markdown
 from markdown_checklist.extension import ChecklistExtension
 
 
-def render_item(checked):
-    checked = ' xecked' if checked else ''
-    return '<li><input type="checkbox" disabled%s>' % checked
+def render_item(caption, checked):
+    checked = ' checked' if checked else ''
+    template = '<li><label><input type="checkbox" disabled%s>%s</label></li>'
+    return template % (checked, caption)
 
 
 def test_checklists():
@@ -17,9 +18,9 @@ def test_checklists():
 
     expected = """
 <ul class="checklist">
-<li><input type="checkbox" disabled> foo</li>
-<li><input type="checkbox" disabled xecked> bar</li>
-<li><input type="checkbox" disabled> baz</li>
+<li><label><input type="checkbox" disabled> foo</label></li>
+<li><label><input type="checkbox" disabled checked> bar</label></li>
+<li><label><input type="checkbox" disabled> baz</label></li>
 </ul>
     """.strip()
 

--- a/test/test_customization.py
+++ b/test/test_customization.py
@@ -17,6 +17,18 @@ def test_checklists():
     """.strip()
 
     expected = """
+<ul class="check-list">
+<li><input type="checkbox" disabled> foo</li>
+<li><input type="checkbox" disabled checked> bar</li>
+<li><input type="checkbox" disabled> baz</li>
+</ul>
+    """.strip()
+
+    html = markdown(source,
+            extensions=[ChecklistExtension(list_class="check-list")])
+    assert html == expected
+
+    expected = """
 <ul class="checklist">
 <li><label><input type="checkbox" disabled> foo</label></li>
 <li><label><input type="checkbox" disabled checked> bar</label></li>


### PR DESCRIPTION
This adds configuration options to customize rendering:

* `list_class` is the class name to add to the list element (defaults to "checkbox")
* `render_item` is a function which defaults to the following:

    ```python
    def render_item(caption, checked):
        checked = ' checked' if checked else ''
        return '<li><input type="checkbox" disabled%s>%s</li>' % (checked, caption)
    ```

These options can be passed when invoking Python Markdown:
```python
from markdown import markdown
from markdown_checklist.extension import ChecklistExtension

html = markdown(source, extensions=[ChecklistExtension(list_class="…", render_item=…)])
```

(Not sure how this works when using `extensions=['markdown_checklist.extension']` instead; I've pretty much forgotten how to operate Python Markdown... )

I'd appreciate a sanity check from @cdent.