### PR TITLE
Paragraph lists

### DIFF
--- a/markdown_checklist/extension.py
+++ b/markdown_checklist/extension.py
@@ -24,7 +24,7 @@ class ChecklistPostprocessor(Postprocessor):
     adds checklist class to list element
     """
 
-    pattern = re.compile(r'<li>\[([ Xx])\]')
+    pattern = re.compile(r'<li>(?:\n<p>)?\[([ Xx])\]')
 
     def run(self, html):
         html = re.sub(self.pattern, self._convert_checkbox, html)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -94,3 +94,31 @@ def test_class():
 <li><input type="checkbox" disabled> ...</li>
 </ul>
     """.strip()
+
+
+def test_newline_in_list():
+    source = """
+- [ ] Foo
+
+- [ ] Bar
+
+    - [ ] Baz
+
+- [ ] lorem
+    """.strip()
+
+    html = markdown(source, extensions=[ChecklistExtension()])
+    assert html == """
+<ul class="checklist">
+<li><input type="checkbox" disabled> Foo</p>
+</li>
+<li><input type="checkbox" disabled> Bar</p>
+<ul class="checklist">
+<li><input type="checkbox" disabled> Baz</li>
+</ul>
+</li>
+<li><input type="checkbox" disabled> lorem</p>
+</li>
+</ul>
+
+    """.strip()


### PR DESCRIPTION
The current pypi release fails for lists that contain newlines between items, which causes the list item to be nested in a paragraph. 

This patch isn't perfect, it leaves the trailing paragraph closing tag which I didn't see a quick way to handle; given this patch doesn't work with the development branch, I thought I might ask you for an integration solution, I didn't have any success with the development branch.

I would suggest that a next release moves to an html specific parser to isolate text from any other html mutators that might interfere with the regex matching.

Project comments:
- Please consider linking to a bug tracker or enabling the Github issue tracker. :bowing_man: 
- Please consider publishing the software license in the project. I had to search into source code to find the license reference by name (MIT).
- Please consider complying with the reproduction terms of the MIT license "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.", I was unable to find any copyright notice, or permission notice anywhere in the published software.
- Please consider attributing yourself as the copyright holder in your license. :)

---
I'm open to a collaborative fix, including authoring/integrating an html text extractor so the regex can parse text instead of text and nasty markup.

Have a nice day :tada: 