### PR TITLE
added license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 FND
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/markdown_checklist/__init__.py
+++ b/markdown_checklist/__init__.py
@@ -59,6 +59,6 @@ There is also a small JavaScript/jQuery library to make checkboxes interactive:
 See included `checklists.js` for details.
 """
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 __author__ = 'FND'
 __license__ = 'MIT'

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ META = {
     'version': VERSION,
     'description': 'Python Markdown extension for task lists with checkboxes',
     'long_description': DESC.strip(),
+    'long_description_content_type': 'text/markdown',
     'license': LICENSE,
     'author': AUTHOR,
     'author_email': '',


### PR DESCRIPTION
> avoids uncertainty for downstream, so why not

this is meant to address #13, but PyPI rejects the package:

> WARNING: Uploading via this command is deprecated, use twine to upload instead (https://pypi.org/p/twine/)
> error: Upload failed (400): The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.

that's despite `long_description_content_type` being set, so I'm giving up for now

https://github.com/FND/markdown-checklist/blob/0808d4bf1232535c186456cab31a76d25c794203/setup.py#L17

https://github.com/FND/markdown-checklist/blob/63ca633bf8d6745e71fafbaa2f5100759ffbbd60/Makefile#L11