### PR TITLE
Modify item regex to allow paragraph breaks

### DIFF
--- a/markdown_checklist/extension.py
+++ b/markdown_checklist/extension.py
@@ -35,7 +35,8 @@ class ChecklistPostprocessor(Postprocessor):
     """
 
     list_pattern = re.compile(r'(<ul>\n<li>\[[ Xx]\])')
-    item_pattern = re.compile(r'^<li>\[([ Xx])\](.*)</li>$', re.MULTILINE)
+    item_pattern = re.compile(r'^<li>\[([ Xx])\](.*?)</li>$',
+                              re.DOTALL | re.MULTILINE)
 
     def __init__(self, list_class, render_item, *args, **kwargs):
         self.list_class = list_class


### PR DESCRIPTION
Before this commit, a list of the form

```
<li>[ ] something</li>
<li>[ ] something else<p>A paragraph break inside</p>
</li>
<li>[ ] regular something</li>
```

renders incorrectly as there is a line break before `</li>`. This can be
output from using the `mdx_truly_sane_lists` extension.

NOTE:

I note that if one doesn't use the truly sane list extension, then
multiparagraph items in a list element don't render correctly before or
after this commit. Without the truly sane list extension, the string

```
- [ ] one
- [ ] two, multiline

  a second para

- [ ] three
```

is converted internally into

```
<li>[ ] one</li>
<li>
<p>[ ] two, multiline</p>
<p>a second para</p>
</li>
<li>[ ] three</li>
```

which is is not detected by the markdown-checklist postprocessor regex
either. I don't handle that in this commit.